### PR TITLE
Fix pyproject.toml link to changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = ["typing_extensions>=4.6"]
 [project.urls]
 homepage = "https://github.com/hauntsaninja/useful_types"
 repository = "https://github.com/hauntsaninja/useful_types"
-changelog = "https://github.com/hauntsaninja/useful_types/blob/master/CHANGELOG.md"
+changelog = "https://github.com/hauntsaninja/useful_types/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["flit_core>=3.8"]


### PR DESCRIPTION
The default branch name is `main` :-)