### PR TITLE
TypeVar for `SupportsAllComparisons`

### DIFF
--- a/useful_types/__init__.py
+++ b/useful_types/__init__.py
@@ -54,6 +54,7 @@ class SupportsAllComparisons(
     SupportsDunderGE[Any],
     Protocol,
 ): ...
+SupportsAllComparisonsT = TypeVar("SupportsAllComparisonsT", bound=SupportsAllComparisons)
 
 
 SupportsRichComparison: TypeAlias = Union[SupportsDunderLT[Any], SupportsDunderGT[Any]]


### PR DESCRIPTION
Many comparison types, like `SupportsRichComparison`, have a `...T` variation which allows for generics bound by that comparison type.  There was not one for `SupportsAllComparisons`, so this patch simply adds one to obviate the need for users to do the same.

I have named this TypeVar in the style of all the others (namely `SupportsAllComparisonsT`); however, I wonder if this should in fact be given a more general name such as the Java-style `Comparable` and `ComparableT`?  That it's nonobvious (to me, at least, ymmv) which `SupportsXXX`  protocol to use is slightly unfortunate and having one named such that This Is Meant To Be The One To Use might go a ways to improving this.  If you feel differently, that's fine too (I can qualify the import to call it whatever I please, after all; it's mostly a discoverability issue for me.)

Thanks!